### PR TITLE
feat(dev): integrate dynamic NestJS module loading in Vite dev server

### DIFF
--- a/examples/base/apps/order/server/order.controller.ts
+++ b/examples/base/apps/order/server/order.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get } from "@nestjs/common";
 
-@Controller()
+@Controller("order")
 export class OrderController {
   @Get()
   getAllOrders() {

--- a/libs/adapters/express/src/adapter/express-adapter.ts
+++ b/libs/adapters/express/src/adapter/express-adapter.ts
@@ -16,7 +16,7 @@ export default defineAdapter({
 
   nestjs: {
     adapter() {
-      return new ExpressAdapter(this.instance);
+      return new ExpressAdapter();
     }
   },
 
@@ -24,7 +24,11 @@ export default defineAdapter({
     instance: express,
 
     use(...middlewares) {
-      this.instance.use(...middlewares);
+      const [middlewareOrPath, ...allMiddlewares] = middlewares;
+      if (typeof middlewareOrPath === "string") {
+        return this.instance.use(middlewareOrPath, ...allMiddlewares);
+      }
+      this.instance.use(middlewareOrPath, ...allMiddlewares);
     },
 
     get(path, ...handlers) {
@@ -45,10 +49,6 @@ export default defineAdapter({
 
     delete(path, ...handlers) {
       this.instance.delete(path, ...handlers);
-    },
-
-    handler() {
-      return this.instance;
     }
   }
 });

--- a/libs/fluxora/dev/package.json
+++ b/libs/fluxora/dev/package.json
@@ -18,6 +18,8 @@
     "@fluxora/router": "workspace:^",
     "@fluxora/runtime": "workspace:^",
     "@fluxora/utils": "workspace:^",
+    "@nestjs/common": "^11.1.0",
+    "@nestjs/core": "^11.1.0",
     "@swc/helpers": "^0.5.17",
     "esbuild": "^0.25.3",
     "lodash.merge": "^4.6.2",

--- a/libs/fluxora/dev/src/core/start-app-dev-server.ts
+++ b/libs/fluxora/dev/src/core/start-app-dev-server.ts
@@ -14,6 +14,7 @@ import { FLUXORA_APP_CONTAINER, VIRTUAL_ENTRIES } from "@fluxora/utils";
 import { PROJECT_CWD } from "@fluxora/utils/node";
 
 import { fluxoraAppPlugin } from "../plugins/fluxora-app.plugin";
+import { nestjsPlugin } from "../plugins/nestjs";
 import { swcPlugin } from "../plugins/swc.plugin";
 import type { Inject } from "../types/inject";
 import { injectHtmlTags } from "../utils/inject-html-tags";
@@ -45,13 +46,14 @@ export const startAppDevServer = async (app: RegisteredApp) => {
 
   environmentContext.checkEnvironment(appModule);
 
-  const server = environmentContext.createServer(adapterContext.server.handler());
+  const server = environmentContext.createServer((req, res) => adapterContext.server.instance(req, res));
 
   const appFrameworkPlugins = appFrameworkContext.plugins;
   const templateFrameworkPlugins = templateFrameworkContext.plugins;
   const adapterPlugins = adapterContext.vite.plugins;
   const plugins = new Set([
     fluxoraAppPlugin(appModule),
+    nestjsPlugin(appModule),
     app.config.framework !== "react" && swcPlugin(),
     __DEV__ && tsconfigPaths({ root: PROJECT_CWD, loose: true }),
     process.env.NODE_ENV === "development" && inspect(),

--- a/libs/fluxora/dev/src/plugins/nestjs/index.ts
+++ b/libs/fluxora/dev/src/plugins/nestjs/index.ts
@@ -1,0 +1,9 @@
+import type { PluginOption } from "vite";
+
+import { RegisteredApp } from "@fluxora/runtime";
+
+import { nestjsServePlugin } from "./nestjs-serve.plugin";
+
+export const nestjsPlugin = (app: RegisteredApp): PluginOption => {
+  return [nestjsServePlugin(app)];
+};

--- a/libs/fluxora/dev/src/plugins/nestjs/nestjs-serve.plugin.ts
+++ b/libs/fluxora/dev/src/plugins/nestjs/nestjs-serve.plugin.ts
@@ -1,0 +1,54 @@
+import { existsSync } from "node:fs";
+
+import type { Plugin } from "vite";
+
+import { adapterRegistry } from "@fluxora/adapter-loader";
+import { RegisteredApp, appCtx } from "@fluxora/runtime";
+import type { WithDefault } from "@fluxora/types";
+import { capitalize } from "@fluxora/utils";
+import { SERVER_ENTRY_FILE_EXTENSIONS, findFile } from "@fluxora/utils/node";
+import { Module, type Type } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+
+export const nestjsServePlugin = (app: RegisteredApp): Plugin => {
+  const adapterContext = adapterRegistry.use(app.config.adapter, app);
+
+  return {
+    name: "fluxora:plugin:nestjs",
+    enforce: "pre",
+    apply: "serve",
+
+    async configureServer(server) {
+      const modulePath = findFile(app.root, `server/${app.name}.module`, SERVER_ENTRY_FILE_EXTENSIONS);
+
+      const imports: Type[] = [];
+      if (modulePath && existsSync(modulePath)) {
+        const module = await appCtx.vite
+          .getSsr(app.name, server)
+          .runner.import<WithDefault<Type, Record<string, Type>>>(modulePath);
+
+        const NestClassModule = module[`${capitalize(app.name)}Module`] || module.AppModule || module.default;
+        if (!NestClassModule) {
+          // ToDo: Handle Error
+          throw new Error(
+            `Module ${modulePath} does not export a class named ${capitalize(app.name)}Module or AppModule`
+          );
+        }
+        Object.defineProperty(NestClassModule, "name", { value: `${capitalize(app.name)}Module` });
+        imports.push(NestClassModule);
+      }
+
+      @Module({ imports })
+      class AppModule {}
+      const prefix = "/api/v1";
+      const nestApp = await NestFactory.create(AppModule, adapterContext.nestjs.adapter());
+      nestApp.setGlobalPrefix(prefix);
+      await nestApp.init();
+      const nestAppServer = nestApp.getHttpAdapter().getInstance();
+      server.middlewares.use(prefix, (req, res, next) => {
+        req.url = prefix + req.url;
+        nestAppServer(req, res, next);
+      });
+    }
+  };
+};

--- a/libs/fluxora/runtime/src/app-ctx/app-context/vite.context.ts
+++ b/libs/fluxora/runtime/src/app-ctx/app-context/vite.context.ts
@@ -10,8 +10,8 @@ export class ViteContext extends BaseClass {
   @ClassGetterSetter()
   declare servers: Map<string, ViteDevServer>;
 
-  getSsr(name: string) {
-    const server = this.servers.get(name);
+  getSsr(name: string, initialServer?: ViteDevServer) {
+    const server = initialServer || this.servers.get(name);
     if (!server) throw new Error("Vite server is not initialized");
     const ssrEnv = server.environments.ssr;
     if (!isRunnableDevEnvironment(ssrEnv)) throw new Error("SSR environment is not runnable");

--- a/libs/fluxora/types/src/adapter/adapter-server.ts
+++ b/libs/fluxora/types/src/adapter/adapter-server.ts
@@ -4,9 +4,12 @@ import type { Connect } from "vite";
 
 type HandleFunction = Connect.NextHandleFunction;
 
-export interface AdapterServer<TInstance = any> {
+export interface AdapterServer<
+  TInstance extends (req: IncomingMessage, res: ServerResponse) => void | Promise<void> = any
+> {
   instance(): TInstance;
 
+  use(this: InternalAdapterServer<TInstance>, path: string, ...methods: HandleFunction[]): void;
   use(this: InternalAdapterServer<TInstance>, ...methods: HandleFunction[]): void;
 
   get(this: InternalAdapterServer<TInstance>, path: string, ...methods: HandleFunction[]): void;
@@ -14,9 +17,8 @@ export interface AdapterServer<TInstance = any> {
   put(this: InternalAdapterServer<TInstance>, path: string, ...methods: HandleFunction[]): void;
   patch(this: InternalAdapterServer<TInstance>, path: string, ...methods: HandleFunction[]): void;
   delete(this: InternalAdapterServer<TInstance>, path: string, ...methods: HandleFunction[]): void;
-
-  handler(this: InternalAdapterServer<TInstance>): (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
 }
 
-export type InternalAdapterServer<TInstance = any> = Record<"instance", TInstance> &
-  Omit<AdapterServer<TInstance>, "instance">;
+export type InternalAdapterServer<
+  TInstance extends (req: IncomingMessage, res: ServerResponse) => void | Promise<void> = any
+> = Record<"instance", TInstance> & Omit<AdapterServer<TInstance>, "instance">;

--- a/libs/fluxora/utils/src/client/decorators/class-extensions.ts
+++ b/libs/fluxora/utils/src/client/decorators/class-extensions.ts
@@ -27,14 +27,12 @@ export const ClassExtensions = (): ClassDecorator => {
             const Class = Reflect.getMetadata("design:type", this, prop);
             const baseClassHandler = decoratorSettings.getBaseClass(Class);
 
-            // console.log(this, prop, Class, baseClassHandler);
-
             Object.defineProperty(this, prop, {
-              enumerable: true,
+              enumerable: false,
               configurable: true,
               get() {
                 if (baseClassHandler && !this[`_${prop}`]) {
-                  const value = baseClassHandler();
+                  const value = baseClassHandler(this);
                   logger.debug(`Creating new instance of ${Class.name} for ${this.constructor.name}.${prop}`, value);
                   this[`_${prop}`] = value;
                 }

--- a/libs/fluxora/utils/src/client/decorators/decorator.settings.ts
+++ b/libs/fluxora/utils/src/client/decorators/decorator.settings.ts
@@ -17,7 +17,7 @@ class DecoratorSettings {
       isSubclassOf(Class, RegisteredClass)
     );
     if (!handler) return;
-    return () => handler[1](handler[0], Class);
+    return (instance: any) => handler[1](instance, Class);
   }
 }
 

--- a/libs/loaders/adapter/src/core/adapter.context.ts
+++ b/libs/loaders/adapter/src/core/adapter.context.ts
@@ -7,7 +7,10 @@ import { BaseClass } from "./base-class";
 
 @ClassRawValues()
 @ClassExtensions()
-export class AdapterContext extends BaseClass<AdapterRegistry> implements Omit<FluxoraAdapter, "name" | "apply"> {
+export class AdapterContext extends BaseClass<AdapterRegistry> implements FluxoraAdapter {
+  @ClassGetterSetter()
+  declare name: string;
+
   @ClassGetterSetter()
   declare nestjs: NestJsAdapterOptions;
 

--- a/libs/loaders/adapter/src/core/adapter.registry.ts
+++ b/libs/loaders/adapter/src/core/adapter.registry.ts
@@ -15,7 +15,7 @@ export class AdapterRegistry extends Registry<FluxoraAdapter, AdapterContext> {
   use(name: string, module: RegisteredModule) {
     const resolvedName = this.resolveName(name);
     const adapter = this.registered.get(resolvedName);
-    if (!adapter) throw new Error(`Environment "${resolvedName}" is not registered.`);
+    if (!adapter) throw new Error(`Adapter "${resolvedName}" is not registered.`);
     const context = super.use(name, module);
     Object.assign(context, adapter);
     context.checks();

--- a/libs/loaders/adapter/src/core/adapter/adapter.server.ts
+++ b/libs/loaders/adapter/src/core/adapter/adapter.server.ts
@@ -16,7 +16,7 @@ function bindThisArg(this: AdapterServer, value: any) {
 @ClassExtensions()
 export class AdapterServer extends BaseClass<AdapterContext> implements IAdapterServer {
   @ClassGetterSetter(undefined, call)
-  declare instance: IAdapterServer["instance"];
+  declare instance: ReturnType<IAdapterServer["instance"]>;
 
   @ClassGetterSetter(undefined, bindThisArg)
   declare use: IAdapterServer["use"];
@@ -35,7 +35,4 @@ export class AdapterServer extends BaseClass<AdapterContext> implements IAdapter
 
   @ClassGetterSetter(undefined, bindThisArg)
   declare delete: IAdapterServer["delete"];
-
-  @ClassGetterSetter()
-  declare handler: IAdapterServer["handler"];
 }

--- a/libs/loaders/adapter/src/core/adapter/nestjs-adapter.options.ts
+++ b/libs/loaders/adapter/src/core/adapter/nestjs-adapter.options.ts
@@ -7,7 +7,7 @@ import { BaseClass } from "../base-class";
 
 function bindThisArg(this: NestJsAdapterOptions, value: any) {
   if (typeof value === "function") {
-    return value.bind(this.parentClass.server);
+    return value.bind(this.parent.server);
   }
   return () => value;
 }

--- a/libs/loaders/adapter/src/core/base-class.ts
+++ b/libs/loaders/adapter/src/core/base-class.ts
@@ -1,19 +1,17 @@
 import { BaseClass as RootBaseClass, decoratorSettings } from "@fluxora/utils";
 
-export class BaseClass<TParentClass> extends RootBaseClass {
-  declare parentClass: TParentClass;
+export class BaseClass<TParent> extends RootBaseClass {
+  declare parent: TParent;
 
-  constructor(parentClass: TParentClass) {
+  constructor(parent: TParent) {
     super();
-    Object.defineProperty(this, "parentClass", {
-      value: parentClass,
+    Object.defineProperty(this, "parent", {
+      value: parent,
       writable: false,
       enumerable: false,
       configurable: false
     });
   }
-
-  checks() {}
 }
 
 decoratorSettings.registerBaseClass(BaseClass, (instance, Class) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,6 +1690,8 @@ __metadata:
     "@fluxora/runtime": "workspace:^"
     "@fluxora/types": "workspace:^"
     "@fluxora/utils": "workspace:^"
+    "@nestjs/common": "npm:^11.1.0"
+    "@nestjs/core": "npm:^11.1.0"
     "@swc/core": "npm:^1.11.22"
     "@swc/helpers": "npm:^0.5.17"
     "@types/lodash.merge": "npm:^4"


### PR DESCRIPTION
- Added `nestjsServePlugin` to dynamically create and initialize NestJS modules during development.
- Registered backend services using NestJS inside the Vite middleware pipeline with global API prefix `/api/v1`.
- Refactored Express adapter to correctly handle both path-based and function-based middleware arguments.
- Removed obsolete `handler` method from `AdapterServer` type and instances.
- Enhanced `AdapterContext` to fully implement `FluxoraAdapter` including `name` field.
- Allowed `ViteContext.getSsr()` to optionally receive an initial server instance for better reuse.
- Improved `BaseClass` and `decoratorSettings` to allow passing instances during base class registration.
- Updated example `OrderController` with explicit `"order"` route prefix.
- Registered `@nestjs/common` and `@nestjs/core` as dependencies in `@fluxora/dev`.
- Improved error handling when attempting to use unregistered adapters.
- Updated `yarn.lock` to reflect newly added NestJS dependencies.